### PR TITLE
mergereplicates: do not require SampleID column

### DIFF
--- a/R/amp_mergereplicates.R
+++ b/R/amp_mergereplicates.R
@@ -73,7 +73,8 @@ amp_mergereplicates <- function(data,
 
   # melt to long format, calculate mean per group and
   # taxon, and cast back to wide format
-  newabund <- data.table::melt(tempabund, id.vars = "SampleID")[
+  sample_id <- names(data$metadata)[1]
+  newabund <- data.table::melt(tempabund, id.vars = sample_id)[
     ,
     .(value = mean(value)),
     by = c(nameoffirstcol, "variable")


### PR DESCRIPTION
according to the docs the first column of the metadata
needs to contain the sample ID, but it is not required
that it has a specific name. See for instance the docs
of amp_load.

mergereplicates did require the sample ID column to be
named SampleID which is changed in this PR.

Seems that there are a few more tools assuming SampleID.. but at least they did not fail in my experiments. 
