### PR TITLE
Ordination plots should use equally scaled axes

### DIFF
--- a/R/amp_ordinate.R
+++ b/R/amp_ordinate.R
@@ -544,6 +544,9 @@ amp_ordinate <- function(data,
     )
   }
 
+  # biplots should be drawn on equally-scaled axes, i.e. with ratio = 1
+  plot <- plot + coord_fixed(ratio = 1)
+  
   ##### Colorframe  #####
   if (!sample_colorframe == FALSE) {
     if (is.null(sample_color_by) & sample_colorframe == TRUE) {


### PR DESCRIPTION
This PR fixes the problem with ordination diagrams raise in Issue #176 through the use of `ggplot2::coord_fixed()` to make the axes of the plot use equal scaling.